### PR TITLE
Fix bugs in how we highlight recently notified PRs

### DIFF
--- a/cmd/goose/github.go
+++ b/cmd/goose/github.go
@@ -634,18 +634,12 @@ func (app *App) fetchTurnDataAsync(ctx context.Context, issues []*github.Issue, 
 	}
 
 	// Only check for newly blocked PRs if there were actual changes
-	// This must happen before UI updates so FirstBlockedAt is set correctly
+	// checkForNewlyBlockedPRs will handle UI updates internally if needed
 	if actualChanges > 0 {
 		app.checkForNewlyBlockedPRs(ctx)
-	}
-
-	// Update tray title and menu with final Turn data if menu is already initialized
-	// This happens after checkForNewlyBlockedPRs so party poppers show correctly
-	app.setTrayTitle()
-	if app.menuInitialized {
-		// Only trigger menu update if PR data actually changed
-		if actualChanges > 0 {
-			app.updateMenu(ctx)
-		}
+		// UI updates are handled inside checkForNewlyBlockedPRs
+	} else {
+		// No changes, but still update tray title in case of initial load
+		app.setTrayTitle()
 	}
 }

--- a/cmd/goose/github.go
+++ b/cmd/goose/github.go
@@ -634,11 +634,13 @@ func (app *App) fetchTurnDataAsync(ctx context.Context, issues []*github.Issue, 
 	}
 
 	// Only check for newly blocked PRs if there were actual changes
+	// This must happen before UI updates so FirstBlockedAt is set correctly
 	if actualChanges > 0 {
 		app.checkForNewlyBlockedPRs(ctx)
 	}
 
 	// Update tray title and menu with final Turn data if menu is already initialized
+	// This happens after checkForNewlyBlockedPRs so party poppers show correctly
 	app.setTrayTitle()
 	if app.menuInitialized {
 		// Only trigger menu update if PR data actually changed

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -597,6 +597,8 @@ func (app *App) checkForNewlyBlockedPRs(ctx context.Context) {
 				// Newly blocked PR
 				newBlockedTimes[incoming[i].URL] = now
 				incoming[i].FirstBlockedAt = now
+				log.Printf("[BLOCKED] Setting FirstBlockedAt for incoming PR: %s #%d at %v",
+					incoming[i].Repository, incoming[i].Number, now)
 
 				// Skip sound and auto-open for stale PRs when hideStaleIncoming is enabled
 				isStale := incoming[i].UpdatedAt.Before(staleThreshold)
@@ -625,6 +627,8 @@ func (app *App) checkForNewlyBlockedPRs(ctx context.Context) {
 				// Newly blocked PR
 				newBlockedTimes[outgoing[i].URL] = now
 				outgoing[i].FirstBlockedAt = now
+				log.Printf("[BLOCKED] Setting FirstBlockedAt for outgoing PR: %s #%d at %v",
+					outgoing[i].Repository, outgoing[i].Number, now)
 
 				// Skip sound and auto-open for stale PRs when hideStaleIncoming is enabled
 				isStale := outgoing[i].UpdatedAt.Before(staleThreshold)
@@ -652,4 +656,11 @@ func (app *App) checkForNewlyBlockedPRs(ctx context.Context) {
 	app.incoming = incoming
 	app.outgoing = outgoing
 	app.mu.Unlock()
+
+	// Update tray title and menu when called from main.go (not from github.go)
+	// This ensures party popper shows for newly blocked PRs
+	if app.menuInitialized {
+		app.setTrayTitle()
+		app.updateMenu(ctx)
+	}
 }

--- a/cmd/goose/ui.go
+++ b/cmd/goose/ui.go
@@ -142,16 +142,21 @@ func (app *App) setTrayTitle() {
 	counts := app.countPRs()
 
 	// Set title based on PR state
+	var title string
 	switch {
 	case counts.IncomingBlocked == 0 && counts.OutgoingBlocked == 0:
-		systray.SetTitle("😊")
+		title = "😊"
 	case counts.IncomingBlocked > 0 && counts.OutgoingBlocked > 0:
-		systray.SetTitle(fmt.Sprintf("🪿 %d 🎉 %d", counts.IncomingBlocked, counts.OutgoingBlocked))
+		title = fmt.Sprintf("🪿 %d 🎉 %d", counts.IncomingBlocked, counts.OutgoingBlocked)
 	case counts.IncomingBlocked > 0:
-		systray.SetTitle(fmt.Sprintf("🪿 %d", counts.IncomingBlocked))
+		title = fmt.Sprintf("🪿 %d", counts.IncomingBlocked)
 	default:
-		systray.SetTitle(fmt.Sprintf("🎉 %d", counts.OutgoingBlocked))
+		title = fmt.Sprintf("🎉 %d", counts.OutgoingBlocked)
 	}
+
+	log.Printf("[TRAY] Setting title: %s (incoming_blocked=%d, outgoing_blocked=%d)",
+		title, counts.IncomingBlocked, counts.OutgoingBlocked)
+	systray.SetTitle(title)
 }
 
 // sortPRsBlockedFirst creates a sorted copy of PRs with blocked ones first.
@@ -208,8 +213,12 @@ func (app *App) addPRSection(ctx context.Context, prs []PR, sectionTitle string,
 				// Use party popper for outgoing PRs, goose for incoming PRs
 				if sectionTitle == "Outgoing" {
 					title = fmt.Sprintf("🎉 %s", title)
+					log.Printf("[MENU] Adding party popper to outgoing PR: %s (blocked %v ago)",
+						sortedPRs[i].URL, time.Since(sortedPRs[i].FirstBlockedAt))
 				} else {
 					title = fmt.Sprintf("🪿 %s", title)
+					log.Printf("[MENU] Adding goose to incoming PR: %s (blocked %v ago)",
+						sortedPRs[i].URL, time.Since(sortedPRs[i].FirstBlockedAt))
 				}
 			} else {
 				title = fmt.Sprintf("• %s", title)

--- a/cmd/goose/ui.go
+++ b/cmd/goose/ui.go
@@ -201,11 +201,16 @@ func (app *App) addPRSection(ctx context.Context, prs []PR, sectionTitle string,
 		}
 
 		title := fmt.Sprintf("%s #%d", sortedPRs[i].Repository, sortedPRs[i].Number)
-		// Add bullet point or goose for blocked PRs
+		// Add bullet point or emoji for blocked PRs
 		if sortedPRs[i].NeedsReview || sortedPRs[i].IsBlocked {
-			// Show goose emoji for PRs blocked within the last hour
+			// Show emoji for PRs blocked within the last hour
 			if !sortedPRs[i].FirstBlockedAt.IsZero() && time.Since(sortedPRs[i].FirstBlockedAt) < time.Hour {
-				title = fmt.Sprintf("🪿 %s", title)
+				// Use party popper for outgoing PRs, goose for incoming PRs
+				if sectionTitle == "Outgoing" {
+					title = fmt.Sprintf("🎉 %s", title)
+				} else {
+					title = fmt.Sprintf("🪿 %s", title)
+				}
 			} else {
 				title = fmt.Sprintf("• %s", title)
 			}


### PR DESCRIPTION
- Newly blocked outgoing PRs should get party popper icon, not geese
- Address drawing race condition that delayed changing the icon
- Better logging